### PR TITLE
A few updates

### DIFF
--- a/src/Clipper.jl
+++ b/src/Clipper.jl
@@ -720,7 +720,7 @@ parameter is the amount to which the supplied paths will be offset - negative
 delta values to shrink polygons and positive delta to expand them.
 
 This method can be called multiple times, offsetting the same paths by different
-amounts (ie using different deltas)
+amounts (ie using different deltas).
 """ ->
 function execute!(c::__ClipperClipperOffset, sol::__ClipperPaths, delta)
     @cxx c->Execute(sol, delta)

--- a/src/Clipper.jl
+++ b/src/Clipper.jl
@@ -321,7 +321,6 @@ function Path(pts::Vector{(Int, Int)})
     p
 end
 
-
 @doc """
 This structure is fundamental to the Clipper Library. It's a list or array of
 one or more Path structures. (The Path structure contains an ordered list of
@@ -337,6 +336,17 @@ contours or 'hole' contours. Which they are depends on orientation.
 """ ->
 function Paths(ct::Integer=0)
     @cxx ClipperLib::Paths(ct)
+end
+
+@doc """
+This function builds a Paths structure from a Vector of Path objects.
+""" ->
+function Paths{T<:__ClipperPath}(paths::Vector{T})
+    pths = Paths()
+    for path in paths
+        push!(pths, path)
+    end
+    pths
 end
 
 @doc """

--- a/src/Clipper.jl
+++ b/src/Clipper.jl
@@ -978,10 +978,6 @@ end
     icxx"$p[$i-1];"
 end
 
-@inline function Base.getindex(p::__ClipperPolyTree, i::Integer)
-    icxx"$p[$i-1];"
-end
-
 @inline function Base.setindex!(path::__ClipperPath, pt::__ClipperIntPoint, i::Integer)
     icxx"$path[$i-1] = $pt;"
 end

--- a/src/Clipper.jl
+++ b/src/Clipper.jl
@@ -1001,7 +1001,7 @@ function Base.show(io::IO, p::__ClipperPath)
         print(io, string("(", x(p[i]), ",", y(p[i]), "), "))
     end
     print(io, string("(", x(p[end]), ",", y(p[end]), ")"))
-    print(")]")
+    print("])")
 end
 
 function Base.show(io::IO, p::__ClipperPaths)

--- a/src/Clipper.jl
+++ b/src/Clipper.jl
@@ -710,7 +710,7 @@ parameter is the amount to which the supplied paths will be offset - negative
 delta values to shrink polygons and positive delta to expand them.
 
 This method can be called multiple times, offsetting the same paths by different
-amounts (ie using different deltas)offset of a polygon with holes
+amounts (ie using different deltas)
 """ ->
 function execute!(c::__ClipperClipperOffset, sol::__ClipperPaths, delta)
     @cxx c->Execute(sol, delta)

--- a/src/Clipper.jl
+++ b/src/Clipper.jl
@@ -45,20 +45,24 @@ typealias __ClipperIntPoint Union(pcpp"ClipperLib::IntPoint",
                                   rcpp"ClipperLib::IntPoint")
 
 # TODO: Remove this when https://github.com/Keno/Cxx.jl/issues/72 is closed
-typealias __ClipperPath Union(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},
-                              Cxx.CppRef{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},
-                              Cxx.CppPtr{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},
-                              Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},
-                              Cxx.CppPtr{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},
-                              Cxx.CppRef{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)})
+typealias __ClipperPath Union(
+    Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},
+    Cxx.CppRef{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},
+    Cxx.CppPtr{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},
+    Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},
+    Cxx.CppRef{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},
+    Cxx.CppPtr{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},
+)
 
 
-typealias __ClipperPaths Union(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},)},(false,false,false)})},(false,false,false)},
+typealias __ClipperPaths Union(
+    Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},)},(false,false,false)})},(false,false,false)},
     Cxx.CppRef{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},)},(false,false,false)})},(false,false,false)},
     Cxx.CppPtr{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},)},(false,false,false)})},(false,false,false)},
     Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},)},(false,false,false)})},(false,false,false)},
+    Cxx.CppRef{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},)},(false,false,false)})},(false,false,false)},
     Cxx.CppPtr{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},)},(false,false,false)})},(false,false,false)},
-    Cxx.CppRef{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::vector")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},Cxx.CppValue{Cxx.CppTemplate{Cxx.CppBaseType{symbol("std::__1::allocator")},(Cxx.CppValue{Cxx.CppBaseType{symbol("ClipperLib::IntPoint")},(false,false,false)},)},(false,false,false)})},(false,false,false)},)},(false,false,false)})},(false,false,false)})
+)
 
 typealias __ClipperClipperBase Union(pcpp"ClipperLib::ClipperBase",
                                   cpcpp"ClipperLib::ClipperBase",
@@ -306,8 +310,11 @@ function Path(ct::Integer=0)
     @cxx ClipperLib::Path(ct)
 end
 
-function Path(pts::Vector{(Int, Int)}, ct::Integer=0)
-    p = Path(ct)
+@doc """
+This function builds a Path structure from a Vector of Tuples.
+""" ->
+function Path(pts::Vector{(Int, Int)})
+    p = Path()
     for point in pts
         push!(p, IntPoint(point...))
     end
@@ -971,6 +978,10 @@ end
     icxx"$p[$i-1];"
 end
 
+@inline function Base.getindex(p::__ClipperPolyTree, i::Integer)
+    icxx"$p[$i-1];"
+end
+
 @inline function Base.setindex!(path::__ClipperPath, pt::__ClipperIntPoint, i::Integer)
     icxx"$path[$i-1] = $pt;"
 end
@@ -1015,22 +1026,28 @@ function Base.show(io::IO, p::__ClipperPath)
     if isempty(p)
         return
     end
-    print("Path([")
+    print(io, "Path([")
     for i = 1:length(p)-1
         print(io, string("(", x(p[i]), ",", y(p[i]), "), "))
     end
     print(io, string("(", x(p[end]), ",", y(p[end]), ")"))
-    print("])")
+    print(io, "])")
 end
 
 function Base.show(io::IO, p::__ClipperPaths)
     len = length(p)
+    if len == 0
+        print(io, "Paths()")
+        return
+    end
+    print(io, "Paths([\n    ")
     for i = 1:len
-        show(io, p[i])
+        print(io, p[i])
         if i < len
-            print(io, "; ")
+            print(io, ",\n    ")
         end
     end
+    print(io, "\n)")
 end
 
 # Clipper basic interface

--- a/src/Clipper.jl
+++ b/src/Clipper.jl
@@ -303,6 +303,14 @@ function Path(ct::Integer=0)
     @cxx ClipperLib::Path(ct)
 end
 
+function Path(pts::Vector{(Int, Int)}, ct::Integer=0)
+    p = Path(ct)
+    for point in pts
+        push!(p, IntPoint(point...))
+    end
+    p
+end
+
 
 @doc """
 This structure is fundamental to the Clipper Library. It's a list or array of
@@ -531,6 +539,10 @@ function Base.length(c::__ClipperPolyTree)
     @cxx c->Total()
 end
 
+function child_count(c::__ClipperPolyTree)
+    @cxx c->ChildCount()
+end
+
 @doc """
 The returned Polynode will be the first child if any, otherwise the next
 sibling, otherwise the next sibling of the Parent etc.
@@ -698,7 +710,7 @@ parameter is the amount to which the supplied paths will be offset - negative
 delta values to shrink polygons and positive delta to expand them.
 
 This method can be called multiple times, offsetting the same paths by different
-amounts (ie using different deltas).
+amounts (ie using different deltas)offset of a polygon with holes
 """ ->
 function execute!(c::__ClipperClipperOffset, sol::__ClipperPaths, delta)
     @cxx c->Execute(sol, delta)
@@ -923,6 +935,10 @@ function Base.push!(a::__ClipperPath,
     @cxx a->push_back(b)
 end
 
+function Base.push!(a::__ClipperPath, b::(Int, Int))
+    push!(a, IntPoint(b...))
+end
+
 function Base.push!(a::__ClipperPaths,
                b::__ClipperPath)
     @cxx a->push_back(b)
@@ -960,6 +976,14 @@ function Base.endof(p::__ClipperPaths)
     length(p)
 end
 
+function ==(a::__ClipperPath, b::__ClipperPath)
+    length(a) != length(b) && return false
+    for i = 1:length(a)
+        a[i] != b[i] && return false
+    end
+    return true
+end
+
 function Base.show(io::IO, v::__ClipperIntPoint)
     print(io, string("(", x(v),",", y(v),")"))
 end
@@ -972,15 +996,21 @@ function Base.show(io::IO, p::__ClipperPath)
     if isempty(p)
         return
     end
+    print("Path([")
     for i = 1:length(p)-1
         print(io, string("(", x(p[i]), ",", y(p[i]), "), "))
     end
     print(io, string("(", x(p[end]), ",", y(p[end]), ")"))
+    print(")]")
 end
 
 function Base.show(io::IO, p::__ClipperPaths)
-    for i = 1:length(p)
+    len = length(p)
+    for i = 1:len
         show(io, p[i])
+        if i < len
+            print(io, "; ")
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,19 @@ push!(a, b)
 push!(a, b)
 println(a)
 
+#test path constructor
+p1 = Path()
+push!(p1, IntPoint(0, 0))
+push!(p1, IntPoint(0, 10))
+push!(p1, IntPoint(10, 10))
+p2 = Path([(0,0), (0,10), (10,10)])
+@test p1 == p2
+
+#test push shortcut
+p = Path()
+push!(p, (0, 0))
+@test p == Path([(0,0)])
+
 # test area
 println("Testing area...")
 p = Path()
@@ -230,3 +243,48 @@ f = first(sol)
 @test child_count(f) == 0
 @show next(f)
 @show parent(f)
+
+# path equality
+println("Testing path equality")
+p1 = Path()
+push!(p1, IntPoint(0,0))
+push!(p1, IntPoint(10,0))
+push!(p1, IntPoint(10,10))
+p2 = Path()
+push!(p2, IntPoint(0,0))
+push!(p2, IntPoint(10,0))
+push!(p2, IntPoint(10,10))
+@test p1 == p2
+
+# offsetting a polygon with holes.
+println("Testing offset of a polygon with holes...")
+perimeter = Path()
+push!(perimeter, IntPoint(-10,-10))
+push!(perimeter, IntPoint(60,-10))
+push!(perimeter, IntPoint(60,60))
+push!(perimeter, IntPoint(-10,60))
+
+hole = Path()
+push!(hole, IntPoint(4,4))
+push!(hole, IntPoint(4,8))
+push!(hole, IntPoint(8,8))
+push!(hole, IntPoint(8,4))
+
+hole2 = Path()
+push!(hole2, IntPoint(12,4))
+push!(hole2, IntPoint(12,8))
+push!(hole2, IntPoint(16,8))
+push!(hole2, IntPoint(16,4))
+
+o = Offset()
+paths = Paths()
+push!(paths, perimeter)
+push!(paths, hole)
+push!(paths, hole2)
+add!(o, paths, jtMiter, etClosedPolygon)
+
+outpaths = Paths()
+execute!(o, outpaths, -2)
+@test length(outpaths) == 2
+@show outpaths[1]
+@show outpaths

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,10 +5,8 @@ using Base.Test
 a = Path()
 b = IntPoint(1,0)
 push!(a, b)
-println(a)
 push!(a, b)
 push!(a, b)
-println(a)
 
 #test path constructor
 p1 = Path()
@@ -180,7 +178,6 @@ bottom!(ir,4)
 @test right(ir) == 2
 @test top(ir) == 3
 @test bottom(ir) == 4
-println(ir)
 
 # test Clip
 println("Testing Clip...")
@@ -245,12 +242,9 @@ execute!(c, ctIntersection, sol)
 @test length(sol) == 1
 f = first(sol)
 @test length(Path(f)) == 4
-@show children(f)
 @test !is_hole(f)
 @test !is_open(f)
 @test child_count(f) == 0
-@show next(f)
-@show parent(f)
 
 # path equality
 println("Testing path equality")
@@ -294,8 +288,8 @@ add!(o, paths, jtMiter, etClosedPolygon)
 outpaths = Paths()
 execute!(o, outpaths, -2)
 @test length(outpaths) == 2
-@show outpaths[1]
-@show outpaths
+@test outpaths[1] == Path([(58,58), (-8,58), (-8,-8), (58,-8)])
+@test outpaths[2] == Path([(18,2), (2,2), (2,10), (18,10)])
 
 p = Path()
 push!(p, IntPoint(0,0))
@@ -305,4 +299,3 @@ push!(p, IntPoint(0,10))
 ps = Paths()
 push!(ps, p)
 pt = Clipper.Basic.offset(ps, 2)
-@show pt

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -298,6 +298,15 @@ execute!(o, outpaths, -2)
 @test outpaths[1] == Path([(58,58), (-8,58), (-8,-8), (58,-8)])
 @test outpaths[2] == Path([(18,2), (2,2), (2,10), (18,10)])
 
+# test Paths() construction from a Vector of Path objects
+paths = Paths([
+    Path([(0,0)]),
+    Path([(10,10)]),
+])
+@test length(paths) == 2
+@test paths[1] == Path([(0,0)])
+@test paths[2] == Path([(10,10)])
+
 # test Paths() printing
 o = IOBuffer()
 show(o, outpaths)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,12 @@ b = IntPoint(1,0)
 push!(a, b)
 push!(a, b)
 push!(a, b)
+o = IOBuffer()
+show(o, b)
+@test ASCIIString(o.data) == "(1,0)"
+o = IOBuffer()
+show(o, a)
+@test ASCIIString(o.data) == "Path([(1,0), (1,0), (1,0)])"
 
 #test path constructor
 p1 = Path()
@@ -245,6 +251,7 @@ f = first(sol)
 @test !is_hole(f)
 @test !is_open(f)
 @test child_count(f) == 0
+@test child_count(sol) == 1
 
 # path equality
 println("Testing path equality")
@@ -290,6 +297,15 @@ execute!(o, outpaths, -2)
 @test length(outpaths) == 2
 @test outpaths[1] == Path([(58,58), (-8,58), (-8,-8), (58,-8)])
 @test outpaths[2] == Path([(18,2), (2,2), (2,10), (18,10)])
+
+# test Paths() printing
+o = IOBuffer()
+show(o, outpaths)
+expected = """Paths([
+    Path([(58,58), (-8,58), (-8,-8), (58,-8)]),
+    Path([(18,2), (2,2), (2,10), (18,10)])
+)"""
+@test ASCIIString(o.data) == expected
 
 p = Path()
 push!(p, IntPoint(0,0))


### PR DESCRIPTION
This PR brings in a few updates:
1. Paths now print themselves as a valid constructor (see output below)
2. Paths can now be constructed from a vector of tuples:
   
   ```
   julia> p = Path([(0, 0), (0, 10), (10, 10)])
   Path([(0,0), (0,10), (10,10)])
   ```

2a. Tuples can be pushed into paths
3. Paths can be compared for equality
4. Some tests of this new functionality
