### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,6 @@
 #! /usr/bin/env julia
 
-pkg_dir = Pkg.dir("Clipper")
+pkg_dir = dirname(dirname(@__FILE__))
 
 @windows_only begin
     try

--- a/src/Clipper.jl
+++ b/src/Clipper.jl
@@ -19,11 +19,11 @@ module Clipper
     @enum EndType EndTypeClosedPolygon=0 EndTypeClosedLine=1 EndTypeOpenSquare=2 EndTypeOpenRound=3 EndTypeOpenButt=4
 
     @windows_only begin
-      const library_path = Pkg.dir("Clipper") * "\\src\\cclipper.dll"
+      const library_path = joinpath(dirname(@__FILE__), "cclipper.dll")
     end
 
     @unix_only begin
-        const library_path = Pkg.dir("Clipper") * "/src/cclipper.so"
+        const library_path = joinpath(dirname(@__FILE__), "cclipper.so")
     end
 
     type IntPoint


### PR DESCRIPTION
minor cleanliness thing for the possibility of someone installing
Clipper.jl either under a different name or outside of Pkg.dir
(bundled with julia or in a system-wide location, for example)
