### PR TITLE
Patch for building with WinRPM gcc.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,6 +12,7 @@ if is_windows()
         WinRPM.install("gcc-c++"; yes = true)
         WinRPM.install("gcc"; yes = true)
         WinRPM.install("headers"; yes = true)
+        WinRPM.install("winpthreads-devel"; yes = true)
 
         gpp = Pkg.dir("WinRPM","deps","usr","x86_64-w64-mingw32","sys-root","mingw","bin","g++")
         RPMbindir = Pkg.dir("WinRPM","deps","usr","x86_64-w64-mingw32","sys-root","mingw","bin")
@@ -37,4 +38,3 @@ if is_unix()
         run(`g++ -shared -o cclipper.so clipper.o cclipper.o`)
     end
 end
-


### PR DESCRIPTION
I tried `Pkg.build("Clipper")` on Windows 10 without having cl.exe installed, and it failed. I used a totally fresh installation (nothing at all was in my .julia folder), with the following `versioninfo()`:

```
Julia Version 0.5.0
Commit 3c9d753 (2016-09-19 18:14 UTC)
Platform Info: System: NT (x86_64-w64-mingw32)
  CPU: Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Haswell)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.7.1 (ORCJIT, haswell)
```

Here's a [log of the build failure](https://gist.github.com/ajkeller34/c7fda29637dd4d86a300f5204ec7e469). With this PR, I am able to build Clipper.jl successfully. There is only a one line change to `deps/build.jl`.
