### PR TITLE
PolyNode, pointinpolygon, precompilation

### DIFF
--- a/test/clipper_test.jl
+++ b/test/clipper_test.jl
@@ -34,6 +34,14 @@ test("Union") do
 
   @test result == true
   @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[0,0],[2,0],[2,1],[0,1]]]"
+
+  result, pt = execute_pt(c, ClipTypeUnion, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
+  @test result == true
+  @test string(pt) == "Top-level PolyNode with 1 immediate children."
+  @test length(children(pt)) === 1
+
+  pn = children(pt)[1]
+  @test string(pn) == "Closed PolyNode with contour:\nClipper.IntPoint[[0,0],[2,0],[2,1],[0,1]]\n...and 0 immediate children."
 end
 
 test("Difference") do
@@ -57,6 +65,15 @@ test("Difference") do
 
   @test result == true
   @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[10,10],[6,10],[6,0],[10,0]],Clipper.IntPoint[[0,10],[0,0],[4,0],[4,10]]]"
+
+  result, pt = execute_pt(c, ClipTypeDifference, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
+  @test result == true
+  @test string(pt) == "Top-level PolyNode with 2 immediate children."
+  @test length(children(pt)) === 2
+
+  pn1,pn2 = (children(pt)...)
+  @test string(pn1) == "Closed PolyNode with contour:\nClipper.IntPoint[[10,10],[6,10],[6,0],[10,0]]\n...and 0 immediate children."
+  @test string(pn2) == "Closed PolyNode with contour:\nClipper.IntPoint[[0,10],[0,0],[4,0],[4,10]]\n...and 0 immediate children."
 end
 
 test("GetBounds") do


### PR DESCRIPTION
As discussed in the comments [here](https://github.com/Voxel8/Clipper.jl/pull/17), this PR reintroduces but does not require the use of `PolyTree`s and `PolyNode`s. To use them, you would do `execute_pt` instead of `execute`. See the tests for examples.

Rather than implementing two types for `PolyNode` and `PolyTree`, I've just made `PolyNode{T}`. This is because in Clipper `PolyTree` is actually a `PolyNode`. Although usually we have `PolyNode{IntPoint}`, I made it a parametric type because this way it is easy to convert to other representations of a 2D point while keeping the tree structure. This is useful for interfacing with other packages.

There were two other changes in this PR:
1. I added a Julia binding for `pointinpolygon` (and tests).
2. I've turned on precompilation since a) the minimum supported Julia version is 0.5, and b) the only dependency is WinRPM, which is only used during the build phase. Therefore it should not cause any problems to have it on.

I'm happy to address any concerns or comments you have.