### PR TITLE
Make tests pass on 0.6 and fix deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ install:
     fi
 julia:
   - 0.5
- # - nightly
+  - 0.6
+  - nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 environment:
   matrix:
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
- # - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:
@@ -15,9 +16,9 @@ notifications:
     on_build_status_changed: false
 
 os: Visual Studio 2015
-platform: 
+platform:
   - x64
-  
+
 install:
   - call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
 # Download most recent Julia Windows binary

--- a/src/Clipper.jl
+++ b/src/Clipper.jl
@@ -38,13 +38,13 @@ module Clipper
         open::Bool
         children::Vector{PolyNode{T}}
         parent::PolyNode{T}
-        PolyNode(a,b,c) = new(a,b,c)
-        function PolyNode(a,b,c,d)
-            p = new(a,b,c,d)
+        (::Type{PolyNode{T}}){T}(a,b,c) = new{T}(a,b,c)
+        function (::Type{PolyNode{T}}){T}(a,b,c,d)
+            p = new{T}(a,b,c,d)
             p.parent = p
             return p
         end
-        PolyNode(a,b,c,d,e) = new(a,b,c,d,e)
+        (::Type{PolyNode{T}}){T}(a,b,c,d,e) = new{T}(a,b,c,d,e)
     end
 
     Base.convert{T}(::Type{PolyNode{T}}, x::PolyNode{T}) = x

--- a/test/clipper_offset_test.jl
+++ b/test/clipper_offset_test.jl
@@ -42,16 +42,20 @@ test("Clear") do
 end
 
 test("Offset") do
-  path = Vector{IntPoint}()
+    path = Vector{IntPoint}()
 
-  push!(path, IntPoint(0, 0))
-  push!(path, IntPoint(0, 1))
+    push!(path, IntPoint(0, 0))
+    push!(path, IntPoint(0, 1))
 
-  c = ClipperOffset()
+    c = ClipperOffset()
 
-  add_path!(c, path, JoinTypeRound, EndTypeOpenRound)
+    add_path!(c, path, JoinTypeRound, EndTypeOpenRound)
 
-  poly = execute(c, 1.0)
+    poly = execute(c, 1.0)
 
-  @test string(poly) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[1,2],[-1,2],[-1,-1],[1,-1]]]"
+    if VERSION >= v"0.6.0-pre"
+      @test string(poly) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[1,2], [-1,2], [-1,-1], [1,-1]]]"
+    else
+      @test string(poly) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[1,2],[-1,2],[-1,-1],[1,-1]]]"
+    end
 end

--- a/test/clipper_test.jl
+++ b/test/clipper_test.jl
@@ -33,22 +33,23 @@ test("Union") do
     result, polys = execute(c, ClipTypeUnion, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
 
     @test result == true
-    if VERSION >= v"0.6.0-pre"
-        @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[0,0], [2,0], [2,1], [0,1]]]"
-    else
-        @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[0,0],[2,0],[2,1],[0,1]]]"
-    end
+    @test polys[1][1] == Clipper.IntPoint(0, 0)
+    @test polys[1][2] == Clipper.IntPoint(2, 0)
+    @test polys[1][3] == Clipper.IntPoint(2, 1)
+    @test polys[1][4] == Clipper.IntPoint(0, 1)
+    
     result, pt = execute_pt(c, ClipTypeUnion, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
     @test result == true
     @test string(pt) == "Top-level PolyNode with 1 immediate children."
     @test length(children(pt)) === 1
 
     pn = children(pt)[1]
-    if VERSION >= v"0.6.0-pre"
-        @test string(pn) == "Closed PolyNode with contour:\nClipper.IntPoint[[0,0], [2,0], [2,1], [0,1]]\n...and 0 immediate children."
-    else
-        @test string(pn) == "Closed PolyNode with contour:\nClipper.IntPoint[[0,0],[2,0],[2,1],[0,1]]\n...and 0 immediate children."
-    end
+
+    @test length(children(pn)) == 0
+    @test contour(pn)[1] == Clipper.IntPoint(0, 0)
+    @test contour(pn)[2] == Clipper.IntPoint(2, 0)
+    @test contour(pn)[3] == Clipper.IntPoint(2, 1)
+    @test contour(pn)[4] == Clipper.IntPoint(0, 1)
 end
 
 test("Difference") do
@@ -71,24 +72,34 @@ test("Difference") do
     result, polys = execute(c, ClipTypeDifference, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
 
     @test result == true
-    if VERSION >= v"0.6.0-pre"
-        @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[10,10], [6,10], [6,0], [10,0]], Clipper.IntPoint[[0,10], [0,0], [4,0], [4,10]]]"
-    else
-        @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[10,10],[6,10],[6,0],[10,0]],Clipper.IntPoint[[0,10],[0,0],[4,0],[4,10]]]"
-    end
+    @test polys[1][1] == Clipper.IntPoint(10, 10)
+    @test polys[1][2] == Clipper.IntPoint(6, 10)
+    @test polys[1][3] == Clipper.IntPoint(6, 0)
+    @test polys[1][4] == Clipper.IntPoint(10, 0)
+
+    @test polys[2][1] == Clipper.IntPoint(0, 10)
+    @test polys[2][2] == Clipper.IntPoint(0, 0)
+    @test polys[2][3] == Clipper.IntPoint(4, 0)
+    @test polys[2][4] == Clipper.IntPoint(4, 10)
+    
     result, pt = execute_pt(c, ClipTypeDifference, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
     @test result == true
     @test string(pt) == "Top-level PolyNode with 2 immediate children."
     @test length(children(pt)) === 2
 
     pn1,pn2 = (children(pt)...)
-    if VERSION >= v"0.6.0-pre"
-        @test string(pn1) == "Closed PolyNode with contour:\nClipper.IntPoint[[10,10], [6,10], [6,0], [10,0]]\n...and 0 immediate children."
-        @test string(pn2) == "Closed PolyNode with contour:\nClipper.IntPoint[[0,10], [0,0], [4,0], [4,10]]\n...and 0 immediate children."
-    else
-        @test string(pn1) == "Closed PolyNode with contour:\nClipper.IntPoint[[10,10],[6,10],[6,0],[10,0]]\n...and 0 immediate children."
-        @test string(pn2) == "Closed PolyNode with contour:\nClipper.IntPoint[[0,10],[0,0],[4,0],[4,10]]\n...and 0 immediate children."
-    end
+    @test length(children(pn1)) == 0
+    @test length(children(pn2)) == 0
+
+    @test contour(pn1)[1] == Clipper.IntPoint(10, 10)
+    @test contour(pn1)[2] == Clipper.IntPoint(6, 10)
+    @test contour(pn1)[3] == Clipper.IntPoint(6, 0)
+    @test contour(pn1)[4] == Clipper.IntPoint(10, 0)
+
+    @test contour(pn2)[1] == Clipper.IntPoint(0, 10)
+    @test contour(pn2)[2] == Clipper.IntPoint(0, 0)
+    @test contour(pn2)[3] == Clipper.IntPoint(4, 0)
+    @test contour(pn2)[4] == Clipper.IntPoint(4, 10)
 end
 
 test("GetBounds") do
@@ -164,11 +175,10 @@ test("AddPaths") do
     result, polys = execute(c, ClipTypeUnion, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
 
     @test result == true
-    if VERSION >= v"0.6.0-pre"
-    @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[0,0], [2,0], [2,1], [0,1]]]"
-    else
-    @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[0,0],[2,0],[2,1],[0,1]]]"
-    end
+    @test polys[1][1] == Clipper.IntPoint(0, 0)
+    @test polys[1][2] == Clipper.IntPoint(2, 0)
+    @test polys[1][3] == Clipper.IntPoint(2, 1)
+    @test polys[1][4] == Clipper.IntPoint(0, 1)
 end
 
 test("Orientation") do
@@ -267,6 +277,7 @@ test("PolyTrees / PolyNodes") do
     @test parent(pt) === pt     # in the wrapper we set the parent of top level to itself
     @test length(children(pt)) === 1
     @test contour(pt) == IntPoint[]     # top level has no contour
+    @test length(children(pt)) == 1
 
     pn1 = children(pt)[1]
     @test !ishole(pn1)
@@ -274,6 +285,11 @@ test("PolyTrees / PolyNodes") do
     @test contour(pn1) == path1
     @test length(children(pn1)) === 1
     @test parent(pn1) === pt
+    @test length(children(pn1)) == 1
+    @test contour(pn1)[1] == Clipper.IntPoint(8, 8)
+    @test contour(pn1)[2] == Clipper.IntPoint(0, 8)
+    @test contour(pn1)[3] == Clipper.IntPoint(0, 0)
+    @test contour(pn1)[4] == Clipper.IntPoint(8, 0)
 
     pn2 = children(pn1)[1]
     @test ishole(pn2)
@@ -281,6 +297,11 @@ test("PolyTrees / PolyNodes") do
     @test contour(pn2) == path2
     @test length(children(pn2)) === 1
     @test parent(pn2) === pn1
+    @test length(children(pn2)) == 1
+    @test contour(pn2)[1] == Clipper.IntPoint(1, 1)
+    @test contour(pn2)[2] == Clipper.IntPoint(1, 7)
+    @test contour(pn2)[3] == Clipper.IntPoint(7, 7)
+    @test contour(pn2)[4] == Clipper.IntPoint(7, 1)
 
     pn3 = children(pn2)[1]
     @test !ishole(pn3)
@@ -288,6 +309,11 @@ test("PolyTrees / PolyNodes") do
     @test contour(pn3) == path3
     @test isempty(children(pn3))
     @test parent(pn3) === pn2
+    @test length(children(pn3)) == 0
+    @test contour(pn3)[1] == Clipper.IntPoint(6, 6)
+    @test contour(pn3)[2] == Clipper.IntPoint(2, 6)
+    @test contour(pn3)[3] == Clipper.IntPoint(2, 2)
+    @test contour(pn3)[4] == Clipper.IntPoint(6, 2)
 
     # Test that we can preserve the tree structure when converting between types.
     pt2 = convert(PolyNode{IntPoint2}, pt)

--- a/test/clipper_test.jl
+++ b/test/clipper_test.jl
@@ -267,7 +267,6 @@ test("PolyTrees / PolyNodes") do
     @test parent(pt) === pt     # in the wrapper we set the parent of top level to itself
     @test length(children(pt)) === 1
     @test contour(pt) == IntPoint[]     # top level has no contour
-    @test string(pt) == "Top-level PolyNode with 1 immediate children."
 
     pn1 = children(pt)[1]
     @test !ishole(pn1)
@@ -275,11 +274,6 @@ test("PolyTrees / PolyNodes") do
     @test contour(pn1) == path1
     @test length(children(pn1)) === 1
     @test parent(pn1) === pt
-    if VERSION >= v"0.6.0-pre"
-        @test string(pn1) == "Closed PolyNode with contour:\nClipper.IntPoint[[8,8], [0,8], [0,0], [8,0]]\n...and 1 immediate children."
-    else
-        @test string(pn1) == "Closed PolyNode with contour:\nClipper.IntPoint[[8,8],[0,8],[0,0],[8,0]]\n...and 1 immediate children."
-    end
 
     pn2 = children(pn1)[1]
     @test ishole(pn2)
@@ -287,11 +281,6 @@ test("PolyTrees / PolyNodes") do
     @test contour(pn2) == path2
     @test length(children(pn2)) === 1
     @test parent(pn2) === pn1
-    if VERSION >= v"0.6.0-pre"
-        @test string(pn2) == "Closed PolyNode (hole) with contour:\nClipper.IntPoint[[1,1], [1,7], [7,7], [7,1]]\n...and 1 immediate children."
-    else
-        @test string(pn2) == "Closed PolyNode (hole) with contour:\nClipper.IntPoint[[1,1],[1,7],[7,7],[7,1]]\n...and 1 immediate children."
-    end
 
     pn3 = children(pn2)[1]
     @test !ishole(pn3)
@@ -299,11 +288,6 @@ test("PolyTrees / PolyNodes") do
     @test contour(pn3) == path3
     @test isempty(children(pn3))
     @test parent(pn3) === pn2
-    if VERSION >= v"0.6.0-pre"
-        @test string(pn3) == "Closed PolyNode with contour:\nClipper.IntPoint[[6,6], [2,6], [2,2], [6,2]]\n...and 0 immediate children."
-    else
-        @test string(pn3) == "Closed PolyNode with contour:\nClipper.IntPoint[[6,6],[2,6],[2,2],[6,2]]\n...and 0 immediate children."
-    end
 
     # Test that we can preserve the tree structure when converting between types.
     pt2 = convert(PolyNode{IntPoint2}, pt)

--- a/test/clipper_test.jl
+++ b/test/clipper_test.jl
@@ -14,169 +14,188 @@ test("Add path to clipper") do
 end
 
 test("Union") do
-  path1 = Vector{IntPoint}()
-  push!(path1, IntPoint(0, 0))
-  push!(path1, IntPoint(0, 1))
-  push!(path1, IntPoint(1, 1))
-  push!(path1, IntPoint(1, 0))
+    path1 = Vector{IntPoint}()
+    push!(path1, IntPoint(0, 0))
+    push!(path1, IntPoint(0, 1))
+    push!(path1, IntPoint(1, 1))
+    push!(path1, IntPoint(1, 0))
 
-  path2 = Vector{IntPoint}()
-  push!(path2, IntPoint(1, 0))
-  push!(path2, IntPoint(1, 1))
-  push!(path2, IntPoint(2, 1))
-  push!(path2, IntPoint(2, 0))
+    path2 = Vector{IntPoint}()
+    push!(path2, IntPoint(1, 0))
+    push!(path2, IntPoint(1, 1))
+    push!(path2, IntPoint(2, 1))
+    push!(path2, IntPoint(2, 0))
 
-  c = Clip()
-  add_path!(c, path1, PolyTypeSubject, true)
-  add_path!(c, path2, PolyTypeSubject, true)
+    c = Clip()
+    add_path!(c, path1, PolyTypeSubject, true)
+    add_path!(c, path2, PolyTypeSubject, true)
 
-  result, polys = execute(c, ClipTypeUnion, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
+    result, polys = execute(c, ClipTypeUnion, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
 
-  @test result == true
-  @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[0,0],[2,0],[2,1],[0,1]]]"
+    @test result == true
+    if VERSION >= v"0.6.0-pre"
+        @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[0,0], [2,0], [2,1], [0,1]]]"
+    else
+        @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[0,0],[2,0],[2,1],[0,1]]]"
+    end
+    result, pt = execute_pt(c, ClipTypeUnion, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
+    @test result == true
+    @test string(pt) == "Top-level PolyNode with 1 immediate children."
+    @test length(children(pt)) === 1
 
-  result, pt = execute_pt(c, ClipTypeUnion, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
-  @test result == true
-  @test string(pt) == "Top-level PolyNode with 1 immediate children."
-  @test length(children(pt)) === 1
-
-  pn = children(pt)[1]
-  @test string(pn) == "Closed PolyNode with contour:\nClipper.IntPoint[[0,0],[2,0],[2,1],[0,1]]\n...and 0 immediate children."
+    pn = children(pt)[1]
+    if VERSION >= v"0.6.0-pre"
+        @test string(pn) == "Closed PolyNode with contour:\nClipper.IntPoint[[0,0], [2,0], [2,1], [0,1]]\n...and 0 immediate children."
+    else
+        @test string(pn) == "Closed PolyNode with contour:\nClipper.IntPoint[[0,0],[2,0],[2,1],[0,1]]\n...and 0 immediate children."
+    end
 end
 
 test("Difference") do
-  path1 = Vector{IntPoint}()
-  push!(path1, IntPoint(0, 0))
-  push!(path1, IntPoint(0, 10))
-  push!(path1, IntPoint(10, 10))
-  push!(path1, IntPoint(10, 0))
+    path1 = Vector{IntPoint}()
+    push!(path1, IntPoint(0, 0))
+    push!(path1, IntPoint(0, 10))
+    push!(path1, IntPoint(10, 10))
+    push!(path1, IntPoint(10, 0))
 
-  path2 = Vector{IntPoint}()
-  push!(path2, IntPoint(4, 0))
-  push!(path2, IntPoint(4, 10))
-  push!(path2, IntPoint(6, 10))
-  push!(path2, IntPoint(6, 0))
+    path2 = Vector{IntPoint}()
+    push!(path2, IntPoint(4, 0))
+    push!(path2, IntPoint(4, 10))
+    push!(path2, IntPoint(6, 10))
+    push!(path2, IntPoint(6, 0))
 
-  c = Clip()
-  add_path!(c, path1, PolyTypeSubject, true)
-  add_path!(c, path2, PolyTypeClip, true)
+    c = Clip()
+    add_path!(c, path1, PolyTypeSubject, true)
+    add_path!(c, path2, PolyTypeClip, true)
 
-  result, polys = execute(c, ClipTypeDifference, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
+    result, polys = execute(c, ClipTypeDifference, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
 
-  @test result == true
-  @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[10,10],[6,10],[6,0],[10,0]],Clipper.IntPoint[[0,10],[0,0],[4,0],[4,10]]]"
+    @test result == true
+    if VERSION >= v"0.6.0-pre"
+        @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[10,10], [6,10], [6,0], [10,0]], Clipper.IntPoint[[0,10], [0,0], [4,0], [4,10]]]"
+    else
+        @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[10,10],[6,10],[6,0],[10,0]],Clipper.IntPoint[[0,10],[0,0],[4,0],[4,10]]]"
+    end
+    result, pt = execute_pt(c, ClipTypeDifference, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
+    @test result == true
+    @test string(pt) == "Top-level PolyNode with 2 immediate children."
+    @test length(children(pt)) === 2
 
-  result, pt = execute_pt(c, ClipTypeDifference, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
-  @test result == true
-  @test string(pt) == "Top-level PolyNode with 2 immediate children."
-  @test length(children(pt)) === 2
-
-  pn1,pn2 = (children(pt)...)
-  @test string(pn1) == "Closed PolyNode with contour:\nClipper.IntPoint[[10,10],[6,10],[6,0],[10,0]]\n...and 0 immediate children."
-  @test string(pn2) == "Closed PolyNode with contour:\nClipper.IntPoint[[0,10],[0,0],[4,0],[4,10]]\n...and 0 immediate children."
+    pn1,pn2 = (children(pt)...)
+    if VERSION >= v"0.6.0-pre"
+        @test string(pn1) == "Closed PolyNode with contour:\nClipper.IntPoint[[10,10], [6,10], [6,0], [10,0]]\n...and 0 immediate children."
+        @test string(pn2) == "Closed PolyNode with contour:\nClipper.IntPoint[[0,10], [0,0], [4,0], [4,10]]\n...and 0 immediate children."
+    else
+        @test string(pn1) == "Closed PolyNode with contour:\nClipper.IntPoint[[10,10],[6,10],[6,0],[10,0]]\n...and 0 immediate children."
+        @test string(pn2) == "Closed PolyNode with contour:\nClipper.IntPoint[[0,10],[0,0],[4,0],[4,10]]\n...and 0 immediate children."
+    end
 end
 
 test("GetBounds") do
-  path1 = Vector{IntPoint}()
-  push!(path1, IntPoint(0, 0))
-  push!(path1, IntPoint(0, 1))
-  push!(path1, IntPoint(1, 1))
-  push!(path1, IntPoint(1, 0))
+    path1 = Vector{IntPoint}()
+    push!(path1, IntPoint(0, 0))
+    push!(path1, IntPoint(0, 1))
+    push!(path1, IntPoint(1, 1))
+    push!(path1, IntPoint(1, 0))
 
-  path2 = Vector{IntPoint}()
-  push!(path2, IntPoint(1, 0))
-  push!(path2, IntPoint(1, 1))
-  push!(path2, IntPoint(2, 1))
-  push!(path2, IntPoint(2, 0))
+    path2 = Vector{IntPoint}()
+    push!(path2, IntPoint(1, 0))
+    push!(path2, IntPoint(1, 1))
+    push!(path2, IntPoint(2, 1))
+    push!(path2, IntPoint(2, 0))
 
-  c = Clip()
-  add_path!(c, path1, PolyTypeSubject, true)
-  add_path!(c, path2, PolyTypeSubject, true)
+    c = Clip()
+    add_path!(c, path1, PolyTypeSubject, true)
+    add_path!(c, path2, PolyTypeSubject, true)
 
-  rect = get_bounds(c)
+    rect = get_bounds(c)
 
-  @test rect.left == 0
-  @test rect.top == 0
-  @test rect.right == 2
-  @test rect.bottom == 1
+    @test rect.left == 0
+    @test rect.top == 0
+    @test rect.right == 2
+    @test rect.bottom == 1
 end
 
 test("Clear") do
-  path1 = Vector{IntPoint}()
-  push!(path1, IntPoint(0, 0))
-  push!(path1, IntPoint(0, 10))
-  push!(path1, IntPoint(10, 10))
-  push!(path1, IntPoint(10, 0))
+    path1 = Vector{IntPoint}()
+    push!(path1, IntPoint(0, 0))
+    push!(path1, IntPoint(0, 10))
+    push!(path1, IntPoint(10, 10))
+    push!(path1, IntPoint(10, 0))
 
-  path2 = Vector{IntPoint}()
-  push!(path2, IntPoint(4, 0))
-  push!(path2, IntPoint(4, 10))
-  push!(path2, IntPoint(6, 10))
-  push!(path2, IntPoint(6, 0))
+    path2 = Vector{IntPoint}()
+    push!(path2, IntPoint(4, 0))
+    push!(path2, IntPoint(4, 10))
+    push!(path2, IntPoint(6, 10))
+    push!(path2, IntPoint(6, 0))
 
-  c = Clip()
-  add_path!(c, path1, PolyTypeSubject, true)
-  add_path!(c, path2, PolyTypeSubject, true)
+    c = Clip()
+    add_path!(c, path1, PolyTypeSubject, true)
+    add_path!(c, path2, PolyTypeSubject, true)
 
-  Clipper.clear!(c)
+    Clipper.clear!(c)
 
-  rect = get_bounds(c)
+    rect = get_bounds(c)
 
-  @test rect.left == 0
-  @test rect.top == 0
-  @test rect.right == 0
-  @test rect.bottom == 0
+    @test rect.left == 0
+    @test rect.top == 0
+    @test rect.right == 0
+    @test rect.bottom == 0
 end
 
 test("AddPaths") do
-  path1 = Vector{IntPoint}()
-  push!(path1, IntPoint(0, 0))
-  push!(path1, IntPoint(0, 1))
-  push!(path1, IntPoint(1, 1))
-  push!(path1, IntPoint(1, 0))
+    path1 = Vector{IntPoint}()
+    push!(path1, IntPoint(0, 0))
+    push!(path1, IntPoint(0, 1))
+    push!(path1, IntPoint(1, 1))
+    push!(path1, IntPoint(1, 0))
 
-  path2 = Vector{IntPoint}()
-  push!(path2, IntPoint(1, 0))
-  push!(path2, IntPoint(1, 1))
-  push!(path2, IntPoint(2, 1))
-  push!(path2, IntPoint(2, 0))
+    path2 = Vector{IntPoint}()
+    push!(path2, IntPoint(1, 0))
+    push!(path2, IntPoint(1, 1))
+    push!(path2, IntPoint(2, 1))
+    push!(path2, IntPoint(2, 0))
 
-  paths = Vector{IntPoint}[path1, path2]
+    paths = Vector{IntPoint}[path1, path2]
 
-  c = Clip()
-  add_paths!(c, paths, PolyTypeSubject, true)
+    c = Clip()
+    add_paths!(c, paths, PolyTypeSubject, true)
 
-  result, polys = execute(c, ClipTypeUnion, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
+    result, polys = execute(c, ClipTypeUnion, PolyFillTypeEvenOdd, PolyFillTypeEvenOdd)
 
-  @test result == true
-  @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[0,0],[2,0],[2,1],[0,1]]]"
+    @test result == true
+    if VERSION >= v"0.6.0-pre"
+    @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[0,0], [2,0], [2,1], [0,1]]]"
+    else
+    @test string(polys) == "Array{Clipper.IntPoint,1}[Clipper.IntPoint[[0,0],[2,0],[2,1],[0,1]]]"
+    end
 end
 
 test("Orientation") do
-  path1 = Vector{IntPoint}()
-  push!(path1, IntPoint(0, 0))
-  push!(path1, IntPoint(0, 1))
-  push!(path1, IntPoint(1, 1))
-  push!(path1, IntPoint(1, 0))
+    path1 = Vector{IntPoint}()
+    push!(path1, IntPoint(0, 0))
+    push!(path1, IntPoint(0, 1))
+    push!(path1, IntPoint(1, 1))
+    push!(path1, IntPoint(1, 0))
 
-  @test orientation(path1) == false
+    @test orientation(path1) == false
 
-  path1 = Vector{IntPoint}()
-  push!(path1, IntPoint(1, 0))
-  push!(path1, IntPoint(1, 1))
-  push!(path1, IntPoint(0, 1))
-  push!(path1, IntPoint(0, 0))
+    path1 = Vector{IntPoint}()
+    push!(path1, IntPoint(1, 0))
+    push!(path1, IntPoint(1, 1))
+    push!(path1, IntPoint(0, 1))
+    push!(path1, IntPoint(0, 0))
 
-  @test orientation(path1) == true
+    @test orientation(path1) == true
 end
 
 test("Area") do
-  path1 = Vector{IntPoint}()
-  push!(path1, IntPoint(0, 0))
-  push!(path1, IntPoint(0, 1))
-  push!(path1, IntPoint(1, 1))
+    path1 = Vector{IntPoint}()
+    push!(path1, IntPoint(0, 0))
+    push!(path1, IntPoint(0, 1))
+    push!(path1, IntPoint(1, 1))
 
-  @test area(path1) == -0.5
+    @test area(path1) == -0.5
 end
 
 test("Point in polygon") do
@@ -256,7 +275,11 @@ test("PolyTrees / PolyNodes") do
     @test contour(pn1) == path1
     @test length(children(pn1)) === 1
     @test parent(pn1) === pt
-    @test string(pn1) == "Closed PolyNode with contour:\nClipper.IntPoint[[8,8],[0,8],[0,0],[8,0]]\n...and 1 immediate children."
+    if VERSION >= v"0.6.0-pre"
+        @test string(pn1) == "Closed PolyNode with contour:\nClipper.IntPoint[[8,8], [0,8], [0,0], [8,0]]\n...and 1 immediate children."
+    else
+        @test string(pn1) == "Closed PolyNode with contour:\nClipper.IntPoint[[8,8],[0,8],[0,0],[8,0]]\n...and 1 immediate children."
+    end
 
     pn2 = children(pn1)[1]
     @test ishole(pn2)
@@ -264,7 +287,11 @@ test("PolyTrees / PolyNodes") do
     @test contour(pn2) == path2
     @test length(children(pn2)) === 1
     @test parent(pn2) === pn1
-    @test string(pn2) == "Closed PolyNode (hole) with contour:\nClipper.IntPoint[[1,1],[1,7],[7,7],[7,1]]\n...and 1 immediate children."
+    if VERSION >= v"0.6.0-pre"
+        @test string(pn2) == "Closed PolyNode (hole) with contour:\nClipper.IntPoint[[1,1], [1,7], [7,7], [7,1]]\n...and 1 immediate children."
+    else
+        @test string(pn2) == "Closed PolyNode (hole) with contour:\nClipper.IntPoint[[1,1],[1,7],[7,7],[7,1]]\n...and 1 immediate children."
+    end
 
     pn3 = children(pn2)[1]
     @test !ishole(pn3)
@@ -272,7 +299,11 @@ test("PolyTrees / PolyNodes") do
     @test contour(pn3) == path3
     @test isempty(children(pn3))
     @test parent(pn3) === pn2
-    @test string(pn3) == "Closed PolyNode with contour:\nClipper.IntPoint[[6,6],[2,6],[2,2],[6,2]]\n...and 0 immediate children."
+    if VERSION >= v"0.6.0-pre"
+        @test string(pn3) == "Closed PolyNode with contour:\nClipper.IntPoint[[6,6], [2,6], [2,2], [6,2]]\n...and 0 immediate children."
+    else
+        @test string(pn3) == "Closed PolyNode with contour:\nClipper.IntPoint[[6,6],[2,6],[2,2],[6,2]]\n...and 0 immediate children."
+    end
 
     # Test that we can preserve the tree structure when converting between types.
     pt2 = convert(PolyNode{IntPoint2}, pt)


### PR DESCRIPTION
The tests on 0.6 were only failing because of some aesthetic changes in how arrays are displayed in Julia 0.6. I added 0.6 and nightly to the tested versions in Travis CI. 

I hope you don't mind that I made indentation four spaces in the test files, to be consistent with typical Julia formatting guidelines... if you find this annoying I can switch back to two spaces with another commit.