### PR TITLE
Change `Base.Test` --> `Test`.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Clipper
-using Base.Test
+using Test
 
 function test(run::Function, name::AbstractString; verbose=true)
     test_name = "Test $(name)"


### PR DESCRIPTION
Should fix the JuliaCIBot failure on Julia 1.0 seen in JuliaLang/METADATA.jl#18559.