### PR TITLE
Added functions for Minkowski sum and difference

### DIFF
--- a/src/Clipper.jl
+++ b/src/Clipper.jl
@@ -309,7 +309,7 @@ function minkowski_sum(poly1::Vector{IntPoint}, poly2::Vector{IntPoint},
 end
 function minkowski_difference(poly1::Vector{IntPoint}, poly2::Vector{IntPoint})
     polys = Vector{Vector{IntPoint}}()
-    @ccall libcclipper.minkoswki_difference(
+    @ccall libcclipper.minkowski_difference(
         poly1::Ptr{IntPoint}, length(poly1)::Csize_t,
         poly2::Ptr{IntPoint}, length(poly2)::Csize_t,
         polys::Any,

--- a/src/Clipper.jl
+++ b/src/Clipper.jl
@@ -9,7 +9,7 @@ export PolyType, PolyTypeSubject, PolyTypeClip, ClipType, ClipTypeIntersection,
        EndTypeClosedLine, EndTypeOpenSquare, EndTypeOpenRound, EndTypeOpenButt, Clip,
        add_path!, add_paths!, execute, clear!, get_bounds, IntPoint, IntRect, orientation,
        area, pointinpolygon, ClipperOffset, PolyNode, execute_pt, contour, ishole, contour,
-       children, tofloat
+       children, tofloat, minkowski_sum, minkowski_difference
 
 @enum PolyType PolyTypeSubject = 0 PolyTypeClip = 1
 
@@ -295,5 +295,27 @@ function simplify_polygons(polys::Vector{Vector{IntPoint}},
                    @cfunction(append_poly!, Any, (Ptr{Cvoid}, Csize_t, IntPoint)))
     return simplified
 end
+
+function minkowski_sum(poly1::Vector{IntPoint}, poly2::Vector{IntPoint},
+        is_closed::Bool = true)
+    polys = Vector{Vector{IntPoint}}()
+    @ccall libcclipper.minkowski_sum(
+        poly1::Ptr{IntPoint}, length(poly1)::Csize_t,
+        poly2::Ptr{IntPoint}, length(poly2)::Csize_t,
+        polys::Any,
+        @cfunction(append_poly!, Any, (Ptr{Cvoid}, Csize_t, IntPoint))::Ptr{Cvoid},
+        is_closed::Cuchar)::Cvoid
+    return polys
+end
+function minkowski_difference(poly1::Vector{IntPoint}, poly2::Vector{IntPoint})
+    polys = Vector{Vector{IntPoint}}()
+    @ccall libcclipper.minkoswki_difference(
+        poly1::Ptr{IntPoint}, length(poly1)::Csize_t,
+        poly2::Ptr{IntPoint}, length(poly2)::Csize_t,
+        polys::Any,
+        @cfunction(append_poly!, Any, (Ptr{Cvoid}, Csize_t, IntPoint))::Ptr{Cvoid})::Cvoid
+    return polys
+end
+
 
 end

--- a/test/clipper_test.jl
+++ b/test/clipper_test.jl
@@ -384,3 +384,9 @@ test("IntPoint to floating point") do
     @test tofloat(point, 3, 4) == (1324.5, 34)
     @test tofloat(point, -4, 4) == (0.00013245, 0.0000034)
 end
+
+test("Minkowski sum") do
+	tri = [IntPoint(0,0), IntPoint(10,0), IntPoint(0,20)]
+	@test minkowski_sum(tri,tri) ==
+		[[IntPoint(0,0), IntPoint(20,0), IntPoint(0,40)]]
+end


### PR DESCRIPTION
This PR adds two exported functions to `Clipper.jl`, `minkowski_sum` and `minkowski_difference`, wrapping the corresponding functions in the C++ library.