### PR TITLE
Upgrade to Clipper2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "Clipper"
 uuid = "c8f6d549-b3ab-5508-a0d1-48fe138e8cc1"
-version = "0.6.3"
+version = "2.0.0"
 
 [deps]
-Clipper_jll = "1721f0f4-5627-55cb-8b31-c466f04189fe"
+Clipper2_jll = "6a795559-3f7e-5382-b5a1-7e858e3d15a4"
 
 [compat]
-Clipper_jll = "6.4.2"
-julia = "1.5"
+Clipper2_jll = "1.2.2"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Clipper"
 uuid = "c8f6d549-b3ab-5508-a0d1-48fe138e8cc1"
-version = "2.0.0"
+version = "0.7.0"
 
 [deps]
 Clipper2_jll = "6a795559-3f7e-5382-b5a1-7e858e3d15a4"

--- a/README.md
+++ b/README.md
@@ -1,16 +1,25 @@
 # Clipper.jl
 
-[![CI](https://github.com/JuliaGeometry/Clipper.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/JuliaGeometry/Clipper.jl/actions/workflows/CI.yml)
-[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliageometry.github.io/Clipper.jl/dev)
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliageometry.github.io/Clipper.jl/stable)
+[![CI][ci-img]][ci-url]
+[![Dev][docs-dev-img]][docs-dev-url]
+[![Stable][docs-stable-img]][docs-stable-url]
 
+Clipper.jl is a Julia wrapper for Angus Johnson's library for polygon clipping and offsetting, [Clipper2 (v1.2.2)](https://github.com/AngusJohnson/Clipper2/tree/Clipper2_1.2.2). 
 
-Clipper.jl is a Julia wrapper for [Angus Johnson's Clipper library (ver. 6.4.2).](http://www.angusj.com/delphi/clipper.php). 
-
-> Clipper - an open source freeware library for clipping and offsetting lines and polygons.
-
-> The Clipper library performs line & polygon clipping - intersection, union, difference & exclusive-or, and line & polygon offsetting. The library is based on Vatti's clipping algorithm.
+> # Clipper2
+> ### A Polygon [Clipping](https://en.wikipedia.org/wiki/Clipping_(computer_graphics)) and [Offsetting](https://en.wikipedia.org/wiki/Parallel_curve) library (in C++, C# & Delphi)
+> 
+> The **Clipper2** library performs **intersection**, **union**, **difference** and **XOR** boolean operations on both simple and complex polygons. It also performs polygon offsetting. This is a major update of my original [**Clipper**](https://sourceforge.net/projects/polyclipping/) library that was written over 10 years ago. That library I'm now calling **Clipper1** and while it still works very well, Clipper2 is [better](http://www.angusj.com/clipper2/Docs/Changes.htm) in just about every way.
 
 ## License
 Available under the [Boost Software License - Version 1.0](http://www.boost.org/LICENSE_1_0.txt).
 See: [LICENSE.md](./LICENSE.md).
+
+[ci-img]: https://github.com/JuliaGeometry/Clipper.jl/actions/workflows/CI.yml/badge.svg?branch=master
+[ci-url]: https://github.com/JuliaGeometry/Clipper.jl/actions/workflows/CI.yml
+
+[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
+[docs-dev-url]: https://juliageometry.github.io/Clipper.jl/dev
+
+[docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
+[docs-stable-url]: https://juliageometry.github.io/Clipper.jl/stable

--- a/src/Clipper.jl
+++ b/src/Clipper.jl
@@ -1,6 +1,6 @@
 module Clipper
 
-using Clipper_jll
+using Clipper2_jll
 
 export PolyType, PolyTypeSubject, PolyTypeClip, ClipType, ClipTypeIntersection,
        ClipTypeUnion, ClipTypeDifference, ClipTypeXor, PolyFillType, PolyFillTypeEvenOdd,
@@ -150,17 +150,17 @@ end
 # Static functions
 #==============================================================#
 function orientation(path::Vector{IntPoint})
-    return ccall((:orientation, libcclipper), Cuchar, (Ptr{IntPoint}, Csize_t), path,
+    return ccall((:orientation, libClipper2), Cuchar, (Ptr{IntPoint}, Csize_t), path,
                  length(path)) == 1
 end
 
 function area(path::Vector{IntPoint})
-    return ccall((:area, libcclipper), Float64, (Ptr{IntPoint}, Csize_t), path,
+    return ccall((:area, libClipper2), Float64, (Ptr{IntPoint}, Csize_t), path,
                  length(path))
 end
 
 function pointinpolygon(pt::IntPoint, path::Vector{IntPoint})
-    return ccall((:pointinpolygon, libcclipper), Cint, (IntPoint, Ptr{IntPoint}, Csize_t),
+    return ccall((:pointinpolygon, libClipper2), Cint, (IntPoint, Ptr{IntPoint}, Csize_t),
                  pt, path, length(path))
 end
 
@@ -171,15 +171,15 @@ mutable struct Clip
     clipper_ptr::Ptr{Cvoid}
 
     function Clip()
-        clipper = new(ccall((:get_clipper, libcclipper), Ptr{Cvoid}, ()))
-        finalizer(c -> ccall((:delete_clipper, libcclipper), Cvoid, (Ptr{Cvoid},),
+        clipper = new(ccall((:get_clipper, libClipper2), Ptr{Cvoid}, ()))
+        finalizer(c -> ccall((:delete_clipper, libClipper2), Cvoid, (Ptr{Cvoid},),
                              c.clipper_ptr), clipper)
         return clipper
     end
 end
 
 function add_path!(c::Clip, path::Vector{IntPoint}, polyType::PolyType, closed::Bool)
-    return ccall((:add_path, libcclipper), Cuchar,
+    return ccall((:add_path, libClipper2), Cuchar,
                  (Ptr{Cvoid}, Ptr{IntPoint}, Csize_t, Cint, Cuchar), c.clipper_ptr, path,
                  length(path), Int(polyType), closed) == 1
 end
@@ -191,7 +191,7 @@ function add_paths!(c::Clip, paths::Vector{Vector{IntPoint}}, polyType::PolyType
         push!(lengths, length(path))
     end
 
-    return ccall((:add_paths, libcclipper), Cuchar,
+    return ccall((:add_paths, libClipper2), Cuchar,
                  (Ptr{Cvoid}, Ptr{Ptr{IntPoint}}, Ptr{Csize_t}, Csize_t, Cint, Cuchar),
                  c.clipper_ptr, paths, lengths, length(paths), Int(polyType), closed) == 1
 end
@@ -200,7 +200,7 @@ function execute(c::Clip, clipType::ClipType, subjFillType::PolyFillType,
                  clipFillType::PolyFillType)
     polys = Vector{Vector{IntPoint}}()
 
-    result = ccall((:execute, libcclipper), Cuchar,
+    result = ccall((:execute, libClipper2), Cuchar,
                    (Ptr{Cvoid}, Cint, Cint, Cint, Any, Ptr{Cvoid}), c.clipper_ptr,
                    Int(clipType), Int(subjFillType), Int(clipFillType), polys,
                    @cfunction(append_poly!, Any, (Ptr{Cvoid}, Csize_t, IntPoint)))
@@ -212,7 +212,7 @@ function execute_pt(c::Clip, clipType::ClipType, subjFillType::PolyFillType,
                     clipFillType::PolyFillType)
     pt = PolyNode{IntPoint}(IntPoint[], false, false, PolyNode{IntPoint}[])
 
-    result = ccall((:execute_pt, libcclipper), Cuchar,
+    result = ccall((:execute_pt, libClipper2), Cuchar,
                    (Ptr{Cvoid}, Cint, Cint, Cint, Any, Ptr{Cvoid}, Ptr{Cvoid}),
                    c.clipper_ptr, Int(clipType), Int(subjFillType), Int(clipFillType), pt,
                    @cfunction(newnode, Ptr{Cvoid}, (Ptr{Cvoid}, Bool, Bool)),
@@ -222,7 +222,7 @@ function execute_pt(c::Clip, clipType::ClipType, subjFillType::PolyFillType,
 end
 
 function clear!(c::Clip)
-    return ccall((:clear, libcclipper), Cvoid, (Ptr{Cvoid},), c.clipper_ptr)
+    return ccall((:clear, libClipper2), Cvoid, (Ptr{Cvoid},), c.clipper_ptr)
 end
 
 mutable struct IntRect
@@ -233,7 +233,7 @@ mutable struct IntRect
 end
 
 function get_bounds(c::Clip)
-    return ccall((:get_bounds, libcclipper), IntRect, (Ptr{Cvoid},), c.clipper_ptr)
+    return ccall((:get_bounds, libClipper2), IntRect, (Ptr{Cvoid},), c.clipper_ptr)
 end
 
 #==============================================================#
@@ -243,9 +243,9 @@ mutable struct ClipperOffset
     clipper_ptr::Ptr{Cvoid}
 
     function ClipperOffset(miterLimit::Float64=2.0, roundPrecision::Float64=0.25)
-        clipper = new(ccall((:get_clipper_offset, libcclipper), Ptr{Cvoid},
+        clipper = new(ccall((:get_clipper_offset, libClipper2), Ptr{Cvoid},
                             (Cdouble, Cdouble), miterLimit, roundPrecision))
-        finalizer(c -> ccall((:delete_clipper_offset, libcclipper), Cvoid, (Ptr{Cvoid},),
+        finalizer(c -> ccall((:delete_clipper_offset, libClipper2), Cvoid, (Ptr{Cvoid},),
                              c.clipper_ptr), clipper)
 
         return clipper
@@ -254,7 +254,7 @@ end
 
 function add_path!(c::ClipperOffset, path::Vector{IntPoint}, joinType::JoinType,
                    endType::EndType)
-    return ccall((:add_offset_path, libcclipper), Cvoid,
+    return ccall((:add_offset_path, libClipper2), Cvoid,
                  (Ptr{Cvoid}, Ptr{IntPoint}, Csize_t, Cint, Cint), c.clipper_ptr, path,
                  length(path), Int(joinType), Int(endType))
 end
@@ -266,18 +266,18 @@ function add_paths!(c::ClipperOffset, paths::Vector{Vector{IntPoint}}, joinType:
         push!(lengths, length(path))
     end
 
-    return ccall((:add_offset_paths, libcclipper), Cvoid,
+    return ccall((:add_offset_paths, libClipper2), Cvoid,
                  (Ptr{Cvoid}, Ptr{Ptr{IntPoint}}, Ptr{Csize_t}, Csize_t, Cint, Cint),
                  c.clipper_ptr, paths, lengths, length(paths), Int(joinType), Int(endType))
 end
 
 function clear!(c::ClipperOffset)
-    return ccall((:clear_offset, libcclipper), Cvoid, (Ptr{Cvoid},), c.clipper_ptr)
+    return ccall((:clear_offset, libClipper2), Cvoid, (Ptr{Cvoid},), c.clipper_ptr)
 end
 
 function execute(c::ClipperOffset, delta::Float64)
     polys = Vector{Vector{IntPoint}}()
-    result = ccall((:execute_offset, libcclipper), Cvoid,
+    result = ccall((:execute_offset, libClipper2), Cvoid,
                    (Ptr{Cvoid}, Cdouble, Any, Ptr{Cvoid}), c.clipper_ptr, delta, polys,
                    @cfunction(append_poly!, Any, (Ptr{Cvoid}, Csize_t, IntPoint)))
 
@@ -289,7 +289,7 @@ function simplify_polygons(polys::Vector{Vector{IntPoint}},
     simplified = Vector{Vector{IntPoint}}()
     counts = Csize_t.(length.(polys))
     count = Csize_t(length(counts))
-    result = ccall((:simplify_polygons, libcclipper), Cvoid,
+    result = ccall((:simplify_polygons, libClipper2), Cvoid,
                    (Ptr{Ptr{IntPoint}}, Ptr{Csize_t}, Csize_t, Cint, Any, Ptr{Cvoid}),
                    polys, counts, count, filltype, simplified,
                    @cfunction(append_poly!, Any, (Ptr{Cvoid}, Csize_t, IntPoint)))
@@ -299,7 +299,7 @@ end
 function minkowski_sum(poly1::Vector{IntPoint}, poly2::Vector{IntPoint},
         is_closed::Bool = true)
     polys = Vector{Vector{IntPoint}}()
-    @ccall libcclipper.minkowski_sum(
+    @ccall libClipper2.minkowski_sum(
         poly1::Ptr{IntPoint}, length(poly1)::Csize_t,
         poly2::Ptr{IntPoint}, length(poly2)::Csize_t,
         polys::Any,
@@ -309,7 +309,7 @@ function minkowski_sum(poly1::Vector{IntPoint}, poly2::Vector{IntPoint},
 end
 function minkowski_difference(poly1::Vector{IntPoint}, poly2::Vector{IntPoint})
     polys = Vector{Vector{IntPoint}}()
-    @ccall libcclipper.minkowski_difference(
+    @ccall libClipper2.minkowski_difference(
         poly1::Ptr{IntPoint}, length(poly1)::Csize_t,
         poly2::Ptr{IntPoint}, length(poly2)::Csize_t,
         polys::Any,


### PR DESCRIPTION
I am opening this draft PR to make [Clipper2](https://github.com/AngusJohnson/Clipper2) available in Julia (and as a means of getting feedback). Once ready, this PR should resolve https://github.com/JuliaGeometry/Clipper.jl/issues/49.

In a previous discussion with @SimonDanisch on Slack ([here](https://julialang.slack.com/archives/C674ELDNX/p1690756637321219)), we agreed to tag a new version in the existing Clipper.jl repository, rather than starting a new repository/package — so that's what I did.

The current status is that a _Clipper2_jll_ for Clipper2 `v1.2.2` has been built using [BinaryBuilder.jl](https://github.com/JuliaPackaging/BinaryBuilder.jl), and it is now available (see https://github.com/JuliaPackaging/Yggdrasil/pull/7093). But that is pretty much it so far, though.